### PR TITLE
Retain notes for skip and followup

### DIFF
--- a/frontend/src/components/donation-form.tsx
+++ b/frontend/src/components/donation-form.tsx
@@ -347,7 +347,7 @@ export function DonationForm({ onCancel, preselectedApartment, onDonationCreated
         currentApartment.tower,
         currentApartment.floor,
         currentApartment.unit,
-        "Skipped by user"
+        formData.notes.trim()
       )
       
       navigateNext()
@@ -367,7 +367,7 @@ export function DonationForm({ onCancel, preselectedApartment, onDonationCreated
         currentApartment.tower,
         currentApartment.floor,
         currentApartment.unit,
-        "Marked for follow-up"
+        formData.notes.trim()
       )
       
       navigateNext()


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Use formData.notes.trim() instead of hardcoded status strings for skip and follow-up actions